### PR TITLE
Fix undefined function error : drupal_check_incompatibility() 

### DIFF
--- a/commands/core/drupal/environment_10.inc
+++ b/commands/core/drupal/environment_10.inc
@@ -39,11 +39,10 @@ function drush_check_module_dependencies($modules, $module_info) {
       foreach ($dependencies as $dependency_name => $v) {
         $current_version = $module_info[$dependency_name]->info['version'];
         $current_version = str_replace(drush_get_drupal_core_compatibility() . '-', '', $current_version);
-        $incompatibility = drupal_check_incompatibility($v, $current_version);
-        if (isset($incompatibility)) {
+        if (!$v->isCompatible($current_version)) {
           $status[$key]['error'] = array(
             'code' => 'DRUSH_PM_ENABLE_DEPENDENCY_VERSION_MISMATCH',
-            'message' => dt('Module !module cannot be enabled because it depends on !dependency !required_version but !current_version is available', array('!module' => $module, '!dependency' => $dependency_name, '!required_version' => $incompatibility, '!current_version' => $current_version))
+            'message' => dt('Module !module cannot be enabled because it depends on !dependency !required_version but !current_version is available', array('!module' => $module, '!dependency' => $dependency_name, '!required_version' => $v->getConstraintString(), '!current_version' => $current_version))
           );
         }
       }

--- a/commands/core/drupal/environment_9.inc
+++ b/commands/core/drupal/environment_9.inc
@@ -39,11 +39,10 @@ function drush_check_module_dependencies($modules, $module_info) {
       foreach ($dependencies as $dependency_name => $v) {
         $current_version = $module_info[$dependency_name]->info['version'];
         $current_version = str_replace(drush_get_drupal_core_compatibility() . '-', '', $current_version);
-        $incompatibility = drupal_check_incompatibility($v, $current_version);
-        if (isset($incompatibility)) {
+        if (!$v->isCompatible($current_version)) {
           $status[$key]['error'] = array(
             'code' => 'DRUSH_PM_ENABLE_DEPENDENCY_VERSION_MISMATCH',
-            'message' => dt('Module !module cannot be enabled because it depends on !dependency !required_version but !current_version is available', array('!module' => $module, '!dependency' => $dependency_name, '!required_version' => $incompatibility, '!current_version' => $current_version))
+            'message' => dt('Module !module cannot be enabled because it depends on !dependency !required_version but !current_version is available', array('!module' => $module, '!dependency' => $dependency_name, '!required_version' => $v->getConstraintString(), '!current_version' => $current_version))
           );
         }
       }


### PR DESCRIPTION
Fix undefined function drupal_check_incompatibility() error.
This function is removed since Drupal 9.

Use \Drupal\Core\Extension\Dependency::isCompatible() instead.