### PR TITLE
Add missing class Role10.php

### DIFF
--- a/lib/Drush/Role/Role10.php
+++ b/lib/Drush/Role/Role10.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Drush\Role;
+
+use Drupal\user\Entity\Role;
+
+class Role10 extends Role9 {
+}


### PR DESCRIPTION
I encountered an error while installing a D10.2 site using a custom profile.
`Unable to load class Drush\Role\Role`

Just adding this missing class fixes the issue for D10.