### PR TITLE
D10+ undefined function error : Restore back drupal_required_modules()

### DIFF
--- a/commands/core/drupal/environment_10.inc
+++ b/commands/core/drupal/environment_10.inc
@@ -7,6 +7,8 @@
  *   is called from.
  */
 
+use Drupal\Core\Extension\ExtensionDiscovery;
+
 include __DIR__ . '/environment_common.inc';
 
 function drush_user_load($uid) {
@@ -52,4 +54,28 @@ function drush_check_module_dependencies($modules, $module_info) {
   }
 
   return $status;
+}
+
+/**
+ * Returns an array of modules required by core.
+ * 
+ * Deprecated in drupal:9.4.0 and is removed from drupal:10.0.0
+ */
+function function drupal_required_modules() {
+   
+    $listing = new ExtensionDiscovery(\Drupal::root());
+    $files = $listing->scan('module');
+    $required = [];
+    // Unless called by the installer, an installation profile is required and
+    // must always be loaded.
+    if ($profile = \Drupal::installProfile()) {
+        $required[] = $profile;
+    }
+    foreach ($files as $name => $file) {
+        $info = \Drupal::service('info_parser')->parse($file->getPathname());
+        if (!empty($info) && !empty($info['required']) && $info['required']) {
+            $required[] = $name;
+        }
+    }
+    return $required;
 }

--- a/commands/core/drupal/environment_11.inc
+++ b/commands/core/drupal/environment_11.inc
@@ -7,6 +7,8 @@
  *   is called from.
  */
 
+use Drupal\Core\Extension\ExtensionDiscovery;
+
 include __DIR__ . '/environment_common.inc';
 
 function drush_user_load($uid) {
@@ -52,4 +54,28 @@ function drush_check_module_dependencies($modules, $module_info) {
   }
 
   return $status;
+}
+
+/**
+ * Returns an array of modules required by core.
+ * 
+ * Deprecated in drupal:9.4.0 and is removed from drupal:10.0.0
+ */
+function function drupal_required_modules() {
+   
+    $listing = new ExtensionDiscovery(\Drupal::root());
+    $files = $listing->scan('module');
+    $required = [];
+    // Unless called by the installer, an installation profile is required and
+    // must always be loaded.
+    if ($profile = \Drupal::installProfile()) {
+        $required[] = $profile;
+    }
+    foreach ($files as $name => $file) {
+        $info = \Drupal::service('info_parser')->parse($file->getPathname());
+        if (!empty($info) && !empty($info['required']) && $info['required']) {
+            $required[] = $name;
+        }
+    }
+    return $required;
 }


### PR DESCRIPTION
Fix error on D10+ :
`Call to undefined function drupal_required_modules() in _drush_drupal_required_modules() (line 50 of /opt/tools/drush/8/drush/commands/core/drupal/environment_common.inc).`

Caused, for example, by running "drush pmu XXX":
